### PR TITLE
Terminate when attach volume fails. Add option to control AZ placement

### DIFF
--- a/doc/providers/aws_ec2.md
+++ b/doc/providers/aws_ec2.md
@@ -88,8 +88,16 @@ target "<address>" "aws_ec2" {
 
   }
 
+  # Control where the instance launches. Optional, but needed if you attach a
+  # volume.
+  placement {
+    availability_zone = "us-west-2d"
+  }
+
   # Optional existing EBS volumes to attach, once the machine is running. This
   # block can be repeated multiple times to attach multiple volumes.
+  # Note that you can only attach a volume to an instance in the same AZ,
+  # so you likely want to set the placement attribute as well.
   attach_volume {
 
     # Name of the device. (Required)

--- a/providers/aws_ec2/impl.go
+++ b/providers/aws_ec2/impl.go
@@ -87,7 +87,6 @@ type hclPlacement struct {
 }
 
 var errAttachVolume = errors.New("failed to attach volume")
-var errUnknown = errors.New("something broke")
 
 const requestTimeout = 30 * time.Second
 

--- a/providers/aws_ec2/impl.go
+++ b/providers/aws_ec2/impl.go
@@ -206,6 +206,7 @@ func (prov *Provider) RunMachine(mach *providers.Machine) {
 		fmt.Printf("Error in Attaching Volumes. Stopping instance\n")
 		prov.stop(mach)
 	} else if err != nil {
+		fmt.Printf("Error in starting machine: %v\n", err)
 		return
 	}
 


### PR DESCRIPTION
Continues this thread: https://github.com/stephank/lazyssh/pull/6#discussion_r587772437

I actually ended up in the state where I had a bunch of zombie instances! 😅 

This fixes that. It also adds the ability to specify the AZ since you can't attach EBS volumes across regions.